### PR TITLE
Use WhatsApp Number as an Unique Dialogflow Session ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,4 @@
 ## Chatbot Whatsapp (OpenSource)
-#### Actualizado Abril 2022
-
-El siguiente proyecto se realizó con fines educativos para el canal de [Youtube (Leifer Mendez)](https://www.youtube.com/channel/UCgrIGp5QAnC0J8LfNJxDRDw?sub_confirmation=1) donde aprendemos a crear y implementar un chatbot increíble usando [node.js](https://codigoencasa.com/tag/nodejs/) además le agregamos inteligencia artificial gracias al servicio de __dialogflow__.
-
-[![Video](https://i.giphy.com/media/OBDi3CXC83WkNeLEZP/giphy.webp)](https://youtu.be/5lEMCeWEJ8o) 
-
-### ATENCION 🔴
-> 💥💥 Si te aparece el Error Multi-device es porque tienes la cuenta de whatsapp afiliada al modo "BETA de Multi dispositivo" por el momento no se tiene soporte para esas personas si tu quieres hacer uso de este __BOT__ debes de salir del modo BETA y intentarlo de la manera tradicional
-
-> El core de whatsapp esta en constante actualizaciones por lo cual siempre revisa la ultima fecha de la actualizacion 
-> [VER](https://github.com/leifermendez/bot-whatsapp/commits/main)
-
-### Busco colaboradores ⭐
-Hola amigos me gusta mucho este proyecto pero por cuestiones de tiempo se me dificulta mantener las actualizaciones si alguno quieres participar en el proyecto escribeme a leifer.contacto@gmail.com
-
-#### Acceso rápido 
-> Si tienes una cuenta en __heroku__ puedes desplegar este proyecto con (1 click)
-
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/leifermendez/bot-whatsapp) 
-
-> Comprarme un cafe!
-
-[![Comprar](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/leifermendez)
 
 #### Actualización
 
@@ -81,7 +58,6 @@ await sendMediaVoiceNote(client, from, 'PTT-20220223-WA0000.opus')
 
 ## Instruciones
 __Descargar o Clonar repositorio__
-![](https://i.imgur.com/dSpUbFz.png)
 
 __Usas ¿Ubuntu / Linux?__
 > Asegurate de instalar los siguientes paquetes
@@ -93,9 +69,9 @@ sudo apt install -y gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups
 __Instalar dependencias (npm install)__
 > Ubicate en le directorio que descargaste y via consola o terminal ejecuta el siguiente comando
 
-`npm install` 
-
-![](https://i.imgur.com/BJuMjGR.png)
+```
+npm i
+``` 
 
 __Configurar .env__
 > Con el editor de texto crea un archivo `.env` el cual debes de guiarte del archivo `.env.example`
@@ -114,21 +90,14 @@ SQL_PASS=
 SQL_DATABASE=
 ```
 
-![](https://i.imgur.com/9poNnW0.png)
-
 __Ejecutar el script__
 > Ubicate en le directorio que descargaste y via consola o terminal ejecuta el siguiente comando
 `npm run start`
 
-![](https://i.imgur.com/eMkBkuJ.png)
-
 __Whatsapp en tu celular__
 > Ahora abre la aplicación de Whatsapp en tu dispositivo y escanea el código QR
 <img src="https://i.imgur.com/RSbPtat.png" width="500"  />
-Visitar la pagina 
-`http://localhost:3000/qr` 
-
-![](https://i.imgur.com/Q3JEDlP.png)
+Tambien puedes visitar la pagina http://127.0.0.1:3000/qr
 
 __Listo 😎__
 > Cuando sale este mensaje tu BOT está __listo__ para trabajar!
@@ -145,11 +114,3 @@ __Listo 😎__
 
 > Ahora deberías  obtener un arespuesta por parte del BOT como la siguiente, ademas de esto tambien se crea un archivo excel
 con el historial de conversación  con el número de tu cliente
-
-![](https://i.imgur.com/lrMLgR8.png)
-![](https://i.imgur.com/UYcoUSV.png)
-
-## Preguntar al BOT
-> Puedes interactuar con el bot ejemplo escribele __hola__ y el bot debe responderte!
-
-![](https://i.imgur.com/cNAS51I.png)

--- a/adapter/diaglogflow.js
+++ b/adapter/diaglogflow.js
@@ -1,6 +1,6 @@
 const dialogflow = require('@google-cloud/dialogflow');
 const fs = require('fs')
-const crypto = require('crypto');
+
 /**
  * Debes de tener tu archivo con el nombre "chatbot-account.json" en la raíz del proyecto
  */
@@ -30,9 +30,9 @@ const checkFileCredentials = () => {
 
 
 // Detect intent method
-const detectIntent = async (queryText) => {
+const detectIntent = async (queryText, waPhoneNumber) => {
     let media = null;
-    const sessionId = KEEP_DIALOG_FLOW ? 1 : crypto.randomUUID();
+    const sessionId = KEEP_DIALOG_FLOW ? 1 : waPhoneNumber;
     const sessionPath = sessionClient.projectAgentSessionPath(PROJECID, sessionId);
     const languageCode = process.env.LANGUAGE
     const request = {
@@ -66,8 +66,8 @@ const detectIntent = async (queryText) => {
     return parseData
 }
 
-const getDataIa = (message = '', cb = () => { }) => {
-    detectIntent(message).then((res) => {
+const getDataIa = (message = '', sessionId = '', cb = () => { }) => {
+    detectIntent(message, sessionId).then((res) => {
         cb(res)
     })
 }

--- a/adapter/index.js
+++ b/adapter/index.js
@@ -52,13 +52,13 @@ const reply = (step) => new Promise((resolve, reject) => {
     }
 })
 
-const getIA = (message) => new Promise((resolve, reject) => {
+const getIA = (message, sessionId) => new Promise((resolve, reject) => {
     /**
      * Si usas dialogflow
      */
      if (process.env.DATABASE === 'dialogflow') {
         let resData = { replyMessage: '', media: null, trigger: null }
-        getDataIa(message,(dt) => {
+        getDataIa(message, sessionId, (dt) => {
             resData = { ...resData, ...dt }
             resolve(resData)
         })

--- a/app.js
+++ b/app.js
@@ -6,7 +6,7 @@ const fs = require('fs');
 const express = require('express');
 const cors = require('cors')
 const qrcode = require('qrcode-terminal');
-const { Client,LocalAuth  } = require('whatsapp-web.js');
+const { Client, LocalAuth } = require('whatsapp-web.js');
 const mysqlConnection = require('./config/mysql')
 const { middlewareClient } = require('./middleware/client')
 const { generateImage, cleanNumber, checkEnvFile, createClient, isValidNumber } = require('./controllers/handle')
@@ -30,7 +30,7 @@ app.use('/', require('./routes/web'))
 const listenMessage = () => client.on('message', async msg => {
     const { from, body, hasMedia } = msg;
 
-    if(!isValidNumber(from)){
+    if (!isValidNumber(from)) {
         return
     }
 
@@ -39,7 +39,7 @@ const listenMessage = () => client.on('message', async msg => {
         return
     }
     message = body.toLowerCase();
-    console.log('BODY',message)
+    console.log('BODY', message)
     const number = cleanNumber(from)
     await readChat(number, message)
 
@@ -56,8 +56,8 @@ const listenMessage = () => client.on('message', async msg => {
      */
 
     if (process.env.DATABASE === 'dialogflow') {
-        if(!message.length) return;
-        const response = await bothResponse(message);
+        if (!message.length) return;
+        const response = await bothResponse(message, number);
         await sendMessage(client, from, response.replyMessage);
         if (response.media) {
             sendMedia(client, from, response.media);
@@ -91,7 +91,7 @@ const listenMessage = () => client.on('message', async msg => {
 
         await sendMessage(client, from, response.replyMessage, response.trigger);
 
-        if(response.hasOwnProperty('actions')){
+        if (response.hasOwnProperty('actions')) {
             const { actions } = response;
             await sendMessageButton(client, from, null, actions);
             return
@@ -116,7 +116,7 @@ const listenMessage = () => client.on('message', async msg => {
         /**
          * Si quieres enviar botones
          */
-        if(response.hasOwnProperty('actions')){
+        if (response.hasOwnProperty('actions')) {
             const { actions } = response;
             await sendMessageButton(client, from, null, actions);
         }
@@ -127,33 +127,33 @@ const listenMessage = () => client.on('message', async msg => {
 
 
 client = new Client({
-        authStrategy: new LocalAuth(),
-        puppeteer: { headless: true }
-    });
-    
+    authStrategy: new LocalAuth(),
+    puppeteer: { headless: true }
+});
+
 client.on('qr', qr => generateImage(qr, () => {
-        qrcode.generate(qr, { small: true });
-        
-        console.log(`Ver QR http://localhost:${port}/qr`)
-        socketEvents.sendQR(qr)
+    qrcode.generate(qr, { small: true });
+
+    console.log(`Ver QR http://localhost:${port}/qr`)
+    socketEvents.sendQR(qr)
 }))
 
 client.on('ready', (a) => {
-        connectionReady()
-        listenMessage()
-        // socketEvents.sendStatus(client)
+    connectionReady()
+    listenMessage()
+    // socketEvents.sendStatus(client)
 });
 
 client.on('auth_failure', (e) => {
-        // console.log(e)
-        // connectionLost()
+    // console.log(e)
+    // connectionLost()
 });
 
 client.on('authenticated', () => {
-        console.log('AUTHENTICATED'); 
+    console.log('AUTHENTICATED');
 });
 
-    client.initialize();
+client.initialize();
 
 
 
@@ -169,4 +169,3 @@ server.listen(port, () => {
     console.log(`El server esta listo por el puerto ${port}`);
 })
 checkEnvFile();
-

--- a/controllers/flows.js
+++ b/controllers/flows.js
@@ -15,8 +15,8 @@ const responseMessages = async (step) => {
     return data
 }
 
-const bothResponse = async (message) => {
-    const data = await getIA(message)
+const bothResponse = async (message, sessionId) => {
+    const data = await getIA(message, sessionId)
     if(data && data.media){
         const file = await saveExternalFile(data.media)
         return {...data,...{media:file}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,13 +22,12 @@
         "qrcode-terminal": "^0.12.0",
         "socket.io": "^4.5.1",
         "stormdb": "^0.6.0",
-        "whatsapp-web.js": "^1.18.0",
+        "whatsapp-web.js": "^1.18.4",
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "pm2": "^5.2.0",
-        "prettier": "2.7.1",
-        "rollup": "^3.2.3"
+        "prettier": "2.7.1"
       },
       "engines": {
         "node": "16.x"
@@ -4242,22 +4241,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/rollup": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.2.3.tgz",
-      "integrity": "sha512-qfadtkY5kl0F5e4dXVdj2D+GtOdifasXHFMiL1SMf9ADQDv5Eti6xReef9FKj+iQPR2pvtqWna57s/PjARY4fg==",
-      "dev": true,
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=14.18.0",
-        "npm": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
     "node_modules/run-series": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.9.tgz",
@@ -5039,9 +5022,9 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/whatsapp-web.js": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/whatsapp-web.js/-/whatsapp-web.js-1.18.0.tgz",
-      "integrity": "sha512-3cCW28/w7llZmTgiO9osumaopOuBBduvyuW02yfy3q9Rz4Wq9Oe1dRedE/kkq764zB8AZcuTs0tE8OKTq2Zobw==",
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/whatsapp-web.js/-/whatsapp-web.js-1.18.4.tgz",
+      "integrity": "sha512-Dqu6Q37tDDAcVJ44aMdRE76sI/9rBCUG+NTz1Kxh2w4obX2WtpoRetilxqgx1r4+pFUl58Lf21wGOEwPZ1pT/A==",
       "dependencies": {
         "@pedroslopez/moduleraid": "^5.0.2",
         "fluent-ffmpeg": "^2.1.2",
@@ -8598,15 +8581,6 @@
         "glob": "^7.1.3"
       }
     },
-    "rollup": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.2.3.tgz",
-      "integrity": "sha512-qfadtkY5kl0F5e4dXVdj2D+GtOdifasXHFMiL1SMf9ADQDv5Eti6xReef9FKj+iQPR2pvtqWna57s/PjARY4fg==",
-      "dev": true,
-      "requires": {
-        "fsevents": "~2.3.2"
-      }
-    },
     "run-series": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.9.tgz",
@@ -9193,9 +9167,9 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "whatsapp-web.js": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/whatsapp-web.js/-/whatsapp-web.js-1.18.0.tgz",
-      "integrity": "sha512-3cCW28/w7llZmTgiO9osumaopOuBBduvyuW02yfy3q9Rz4Wq9Oe1dRedE/kkq764zB8AZcuTs0tE8OKTq2Zobw==",
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/whatsapp-web.js/-/whatsapp-web.js-1.18.4.tgz",
+      "integrity": "sha512-Dqu6Q37tDDAcVJ44aMdRE76sI/9rBCUG+NTz1Kxh2w4obX2WtpoRetilxqgx1r4+pFUl58Lf21wGOEwPZ1pT/A==",
       "requires": {
         "@pedroslopez/moduleraid": "^5.0.2",
         "archiver": "^5.3.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "qrcode-terminal": "^0.12.0",
     "socket.io": "^4.5.1",
     "stormdb": "^0.6.0",
-    "whatsapp-web.js": "latest",
+    "whatsapp-web.js": "^1.18.4",
     "xlsx": "^0.18.5"
   },
   "devDependencies": {


### PR DESCRIPTION
## Problema
Issues #44 #74 
Cada vez que se manda un MENSAJE (independientemente si es de diferentes chats/números de teléfono), ese mensaje se envía con un sessionID único/diferente, por lo que Dialogflow "asume" que es una nueva conversación, eso no esta bien, porque no puede haber contextos de esa manera, La opción actual es en el `.env` `KEEP_DIALOG_FLOW=true` lo que va a asignarle a cada mensaje el sessionID "1". Claro, esto crea otro problema; si 10 personas están "chateando" con el bot, Dialogflow "asume" que es una sola conversación, lo que puede crear un desastre si tienes un sistema de contextos medianamente complejo.

## Solución
La solución es modificar (en esta línea): https://github.com/leifermendez/bot-whatsapp/blob/8a4f134327ccb608f2b03a5cd937beab79a96f27/adapter/diaglogflow.js#L35 para que la sessionID asignada sea el número de teléfono (que es único) en lugar de usar `crypto.randomUUID()`, de esa manera se mantendría una contexto separado por usuario. 

fix 1884832192e00ea4b6a70bd6660cb57a24ad3e50